### PR TITLE
Remove dice icon from the site header, streamlining the visual design

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A full-stack online casino platform focused on slot games, built with React, Express, and PostgreSQL.
 
 ## Features
-
 - Multiple slot games with different themes and mechanics
 - Real-time functionality using WebSockets
 - Virtual balance system with betting

--- a/client/src/components/ui/header.tsx
+++ b/client/src/components/ui/header.tsx
@@ -4,7 +4,7 @@ import { useBalanceContext } from '@/contexts/balance-context';
 import { useAuth } from '@/hooks/use-auth';
 import { useAuthModal } from '@/contexts/auth-modal-context';
 import { formatCurrency } from '@/lib/utils';
-import { Dice5, Coins, ChevronDown, LogIn, UserPlus } from 'lucide-react';
+import { Coins, ChevronDown, LogIn, UserPlus } from 'lucide-react';
 import { GiTopHat } from 'react-icons/gi';
 import { Button } from './button';
 
@@ -23,7 +23,6 @@ export function Header() {
         {/* Centered Logo */}
         <div className="flex items-center justify-center">
           <Link href="/" className="flex items-center group">
-            <Dice5 className="text-primary text-4xl mr-3" />
             <span className="font-heading font-bold text-3xl bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
               LUCKY SPIN
             </span>


### PR DESCRIPTION
Removes the Dice5 icon import and usage from `client/src/components/ui/header.tsx`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: f0ea77aa-bcab-4184-a899-21cb07879130
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/2696e305-0bf0-4f5c-a030-4c0d94d8cbdf/0a54efef-a081-4e90-98c8-bcbc21e8bb5a.jpg